### PR TITLE
pushing to queue in drain causes assertion

### DIFF
--- a/lib/vasync.js
+++ b/lib/vasync.js
@@ -291,10 +291,9 @@ WorkQueue.prototype.dispatch = function (entry)
 				entry['callback'](err);
 
 			if (wq.drain && wq.npending === 0 &&
-			    wq.queued.length === 0)
+			    wq.queued.length === 0) {
 				wq.drain();
-
-			if (wq.queued.length > 0) {
+			} else if (wq.queued.length > 0) {
 				var next = wq.queued.shift();
 				wq.dispatch(next);
 


### PR DESCRIPTION
Avoid the case where items were pushed into the queue from the drain function resulting in the worker trying to dispatch more than concurrency allows.
