### PR TITLE
allow "funcs" to be specified directly for pipeline and parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ asynchronous: they get a "callback" argument and should invoke it as
 `callback(err, result)`.  The error and result will be saved and made available
 to the original caller when all of these functions complete.
 
+If `args` is an array, it will be used as the `funcs` property for convenience.
+
 This function returns the same "result" object it passes to the callback, and
 you can use the fields in this object to debug or observe progress:
 
@@ -184,6 +186,8 @@ The named arguments (that go inside `args`) are:
 
 * `funcs`: input functions, to be invoked in series
 * `arg`: arbitrary argument that will be passed to each function
+
+If `args` is an array, it will be used as the `funcs` property for convenience.
 
 The functions are invoked in order as `func(arg, callback)`, where "arg" is the
 user-supplied argument from "args" and "callback" should be invoked in the usual

--- a/lib/vasync.js
+++ b/lib/vasync.js
@@ -50,6 +50,9 @@ function parallel(args, callback)
 {
 	var funcs, rv, doneOne, i;
 
+	if (Array.isArray(args))
+		args = {funcs: args};
+
 	mod_assert.equal(typeof (args), 'object', '"args" must be an object');
 	mod_assert.ok(Array.isArray(args['funcs']),
 	    '"args.funcs" must be specified and must be an array');
@@ -150,6 +153,9 @@ function forEachParallel(args, callback)
 function pipeline(args, callback)
 {
 	var funcs, uarg, rv, next;
+
+	if (Array.isArray(args))
+		args = {funcs: args};
 
 	mod_assert.equal(typeof (args), 'object', '"args" must be an object');
 	mod_assert.ok(Array.isArray(args['funcs']),


### PR DESCRIPTION
this allows for a level of indentation to be dropped, which can be useful when trying to stay within 80 columns for source files that make complex use of vasync (looking at [VM.js](https://github.com/joyent/smartos-live/blob/master/src/vm/node_modules/VM.js))

Before

``` js
vasync.parallel({
    'funcs': [
        function f1 (cb) { cb(); },
        function f2 (cb) { cb(); },
        function f3 (cb) { cb(); },
    ]
}, function (err, results) {
    console.log('done');
});
```

After

``` js
vasync.parallel([
    function f1 (cb) { cb(); },
    function f2 (cb) { cb(); },
    function f3 (cb) { cb(); },
], function (err, results) {
    console.log('done');
});
```