### PR TITLE
fix cross-VM assertion bug

### DIFF
--- a/lib/vasync.js
+++ b/lib/vasync.js
@@ -538,7 +538,7 @@ function waterfall(funcs, callback)
 	var rv, current, next;
 
 	mod_assert.ok(Array.isArray(funcs));
-	mod_assert.ok(arguments.length == 1 || callback instanceof Function);
+	mod_assert.ok(arguments.length == 1 || typeof callback === 'function');
 	funcs = funcs.slice(0);
 
 	rv = {


### PR DESCRIPTION
@davepacheco 
The changed line (541) will always result in an assertion error when a callback is given, but vasync.waterfall() is called from a different VM in Node.JS.
This behavior of `instanceof` can also be observed in a browser when used from different iframes.