### PR TITLE
Add VASYNC_MODE=direct setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,3 +592,13 @@ This example outputs:
     first task ends
     second task begins
     second task ends
+
+## Usage with synchronous test libraries
+
+Some mockup libraries (like testdouble) makes it easy to turn asynchronous code
+into synchronous code (for easier testing). By default, vasync breaks synchronous
+flow by calling your callbacks inside a `setImmediate` block.
+
+This behaviour is desirable in production (generally also when running tests),
+yet it can be disabled by setting the `VASYNC_MODE` environment variable to
+`direct` when required.

--- a/lib/vasync.js
+++ b/lib/vasync.js
@@ -19,8 +19,14 @@ exports.queuev = queuev;
 exports.barrier = barrier;
 exports.waterfall = waterfall;
 
-if (!global.setImmediate) {
-	global.setImmediate = function (func) {
+var setImmediate = global.setImmediate;
+
+if (process.env.VASYNC_MODE == "direct") {
+	setImmediate = function(func) {
+		func();
+	};
+} else if (!setImmediate) {
+	setImmediate = function (func) {
 		var args = Array.prototype.slice.call(arguments, 1);
 		args.unshift(0);
 		args.unshift(func);


### PR DESCRIPTION
Some mockup libraries (like testdouble) makes it easy to turn synchronous code into synchronous code (for easier testing).

By default, vasync breaks synchronous flow by calling callbacks inside a `setImmediate` block.

While this is desirable in production (generally also when running tests), it is also useful to let the user disable this behavior when required.